### PR TITLE
Add seed flag to allow reproducibility

### DIFF
--- a/src/libfm/libfm.cpp
+++ b/src/libfm/libfm.cpp
@@ -61,7 +61,6 @@ using namespace std;
 
 int main(int argc, char **argv) { 
  	
- 	srand ( time(NULL) );
 	try {
 		CMDLine cmdline(argc, argv);
 		std::cout << "----------------------------------------------------------------------------" << std::endl;
@@ -91,6 +90,8 @@ int main(int argc, char **argv) {
 
 		const std::string param_verbosity	= cmdline.registerParameter("verbosity", "how much infos to print; default=0");
 		const std::string param_r_log		= cmdline.registerParameter("rlog", "write measurements within iterations to a file; default=''");
+		const std::string param_seed		= cmdline.registerParameter("seed", "integer value, default=None");
+
 		const std::string param_help            = cmdline.registerParameter("help", "this screen");
 
 		const std::string param_relation	= cmdline.registerParameter("relation", "BS: filenames for the relations, default=''");
@@ -107,6 +108,10 @@ int main(int argc, char **argv) {
 			return 0;
 		}
 		cmdline.checkParameters();
+		
+		// Seed
+		long int seed = cmdline.getValue(param_seed, time(NULL));
+		srand ( seed );
 
 		if (! cmdline.hasParameter(param_method)) { cmdline.setValue(param_method, "mcmc"); }
 		if (! cmdline.hasParameter(param_init_stdev)) { cmdline.setValue(param_init_stdev, "0.1"); }

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -138,6 +138,14 @@ class CMDLine {
 				return default_value;
 			}
 		}
+		
+		const long int getValue(const std::string& parameter, const long int& default_value) {
+			if (hasParameter(parameter)) {
+				return atoi(value[parameter].c_str());
+			} else {
+				return default_value;
+			}
+		}
 
 		const int getValue(const std::string& parameter, const int& default_value) {
 			if (hasParameter(parameter)) {


### PR DESCRIPTION
Instead of using only unix timestamp to initialize a pseudorandom number generator, we can pass our own seed flag is "-seed" followed by a (integer / long int) number
