### PR TITLE
Make wasn't working for Windows

### DIFF
--- a/src/util/util.h
+++ b/src/util/util.h
@@ -22,7 +22,6 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
-#include <math.h>
 #include <vector>
 #include <ctime>
 
@@ -45,6 +44,8 @@ namespace std {
 	bool isinf(float f) { return (! _finite(f)) && (! isnan(f)); }
 }
 #endif
+
+#include <math.h>
 
 double sqr(double d) { return d*d; }
 


### PR DESCRIPTION
make was not working on my Windows machine. Based on the error messages I got, this [thread](http://stackoverflow.com/a/9888306) indicated that the issue was a conflict with defining `isinf` and `#include <math.h>`. After moving `#include <math.h>` after `isinf`, I was able to successfully run make. 