### PR TITLE
fix model save for ALS

### DIFF
--- a/src/libfm/libfm.cpp
+++ b/src/libfm/libfm.cpp
@@ -92,7 +92,7 @@ int main(int argc, char **argv) {
 		const std::string param_r_log		= cmdline.registerParameter("rlog", "write measurements within iterations to a file; default=''");
 		const std::string param_seed		= cmdline.registerParameter("seed", "integer value, default=None");
 
-		const std::string param_help            = cmdline.registerParameter("help", "this screen");
+		const std::string param_help	    	= cmdline.registerParameter("help", "this screen");
 
 		const std::string param_relation	= cmdline.registerParameter("relation", "BS: filenames for the relations, default=''");
 
@@ -118,6 +118,11 @@ int main(int argc, char **argv) {
 		if (! cmdline.hasParameter(param_method)) { cmdline.setValue(param_method, "mcmc"); }
 		if (! cmdline.hasParameter(param_init_stdev)) { cmdline.setValue(param_init_stdev, "0.1"); }
 		if (! cmdline.hasParameter(param_dim)) { cmdline.setValue(param_dim, "1,1,8"); }
+
+		if (cmdline.hasParameter(param_save_model) && !cmdline.getValue(param_method).compare("mcmc")) {
+			std::cout << "**WARNING**: load/save enabled only for SGD and ALS. Nothing will be saved." << std::endl;
+			cmdline.setValue(param_save_model, "FALSE_MCMC_SAVE");
+		}
 
 		if (! cmdline.getValue(param_method).compare("als")) { // als is an mcmc without sampling and hyperparameter inference
 			cmdline.setValue(param_method, "mcmc");
@@ -422,14 +427,9 @@ int main(int argc, char **argv) {
 		}
 		
 		// () save the FM model
-		if (cmdline.hasParameter(param_save_model)) {
-			std::cout << "Writing FM model... \t" << std::endl;
-			if (!cmdline.getValue(param_method).compare("sgd") || !cmdline.getValue(param_method).compare("als")){ //load/save enabled only for SGD and ALS
-				fm.saveModel(cmdline.getValue(param_save_model));
-			}
-			else{
-				std::cout << "WARNING: load/save enabled only for SGD and ALS. Nothing will be saved." << std::endl;
-			}
+		if (cmdline.hasParameter("save_model") && cmdline.getValue(param_save_model).compare("FALSE_MCMC_SAVE")) {
+			std::cout << "Writing FM model to "<< cmdline.getValue(param_save_model) << std::endl;
+			fm.saveModel(cmdline.getValue(param_save_model));
 		}
 				 	
 

--- a/src/libfm/libfm.cpp
+++ b/src/libfm/libfm.cpp
@@ -119,10 +119,11 @@ int main(int argc, char **argv) {
 		if (! cmdline.hasParameter(param_init_stdev)) { cmdline.setValue(param_init_stdev, "0.1"); }
 		if (! cmdline.hasParameter(param_dim)) { cmdline.setValue(param_dim, "1,1,8"); }
 
-		if (cmdline.hasParameter(param_save_model) && !cmdline.getValue(param_method).compare("mcmc")) {
-			std::cout << "**WARNING**: load/save enabled only for SGD and ALS. Nothing will be saved." << std::endl;
-			cmdline.setValue(param_save_model, "FALSE_MCMC_SAVE");
-		}
+        if (! cmdline.getValue(param_method).compare("mcmc") && cmdline.hasParameter(param_save_model)) {
+			std::cout << "WARNING: -save_model enabled only for SGD and ALS." << std::endl;
+            cmdline.removeParameter(param_save_model);
+            return 0;
+        }
 
 		if (! cmdline.getValue(param_method).compare("als")) { // als is an mcmc without sampling and hyperparameter inference
 			cmdline.setValue(param_method, "mcmc");
@@ -427,7 +428,7 @@ int main(int argc, char **argv) {
 		}
 		
 		// () save the FM model
-		if (cmdline.hasParameter("save_model") && cmdline.getValue(param_save_model).compare("FALSE_MCMC_SAVE")) {
+		if (cmdline.hasParameter(param_save_model)) {
 			std::cout << "Writing FM model to "<< cmdline.getValue(param_save_model) << std::endl;
 			fm.saveModel(cmdline.getValue(param_save_model));
 		}

--- a/src/util/cmdline.h
+++ b/src/util/cmdline.h
@@ -81,6 +81,11 @@ class CMDLine {
 			return (value.find(parameter) != value.end());
 		}
 
+		void removeParameter(const std::string& parameter) {
+			if (hasParameter(parameter)) {
+				value.erase(parameter);
+			}
+		}
 		
 		void print_help() {
 			for (std::map< std::string, std::string >::const_iterator pv = help.begin(); pv != help.end(); ++pv) {
@@ -109,7 +114,7 @@ class CMDLine {
 			this->help[parameter] = help;
 			return parameter;
 		}
-
+        
 		void checkParameters() {
 			// make sure there is no parameter specified on the cmdline that is not registered:
 			for (std::map< std::string, std::string >::const_iterator pv = value.begin(); pv != value.end(); ++pv) {


### PR DESCRIPTION
#24 
The original implementation doesn't provide the model saving function, so it resets "param_method" from ALS to MCMC. Here I add an additional flag to enable the saving function for ALS.