### PR TITLE
add -relationN for eliminating the inner-interactions

### DIFF
--- a/src/libfm/src/Data.h
+++ b/src/libfm/src/Data.h
@@ -95,6 +95,7 @@ class Data {
 		DATA_FLOAT max_target;
 
 		DVector<RelationJoin> relation;
+		DVector<RelationJoin> relationN;
 		
 		void load(std::string filename);	
 		void debug();

--- a/src/libfm/src/fm_learn_mcmc.h
+++ b/src/libfm/src/fm_learn_mcmc.h
@@ -97,6 +97,7 @@ class fm_learn_mcmc : public fm_learn {
 		e_q_term* cache_test;
 
 		DVector<relation_cache*> rel_cache;
+		DVector<relation_cache*> relN_cache;
 
 		virtual void _learn(Data& train, Data& test) {};
 	
@@ -111,6 +112,7 @@ class fm_learn_mcmc : public fm_learn {
 			if (main_data.dim == 0) { return ; }
  
 			DVector<RelationJoin>& relation = main_data(0)->relation;
+			DVector<RelationJoin>& relationN = main_data(0)->relationN;
 
 			// do this using only the transpose copy of the training data:
 			for (uint ds = 0; ds < main_cache.dim; ds++) {
@@ -122,10 +124,16 @@ class fm_learn_mcmc : public fm_learn {
 				} 	
 			}
 
-			for (uint r = 0; r < relation.dim; r++) {
+			for (uint r = 0; r < relation.dim; r++) { // Relation
 				for (uint c = 0; c < relation(r).data->num_cases; c++) {
 					rel_cache(r)[c].y = 0.0;
 					rel_cache(r)[c].q = 0.0;
+				}
+			}
+			for (uint r = 0; r < relationN.dim; r++) { // Relation N
+				for (uint c = 0; c < relationN(r).data->num_cases; c++) {
+					relN_cache(r)[c].y = 0.0;
+					relN_cache(r)[c].q = 0.0;
 				}
 			}
 
@@ -162,7 +170,7 @@ class fm_learn_mcmc : public fm_learn {
 
 				// calculate block_cache[i].q = sum_i v^B_if x^B_i (== q^B_f-term)
 				// Complexity: O(\sum_{B} N_z(X^B))
-				for (uint r = 0; r < relation.dim; r++) {
+				for (uint r = 0; r < relation.dim; r++) { // Relation
 					uint attr_offset = relation(r).data->attr_offset;
 					relation(r).data->data_t->begin();
 					uint row_index;
@@ -183,6 +191,27 @@ class fm_learn_mcmc : public fm_learn {
 					}
 					
 				}
+				for (uint r = 0; r < relationN.dim; r++) { // RelationN
+					uint attr_offset = relationN(r).data->attr_offset;
+					relationN(r).data->data_t->begin();
+					uint row_index;
+					sparse_row<DATA_FLOAT>* feature_data;
+					for (uint i = 0; i < relationN(r).data->data_t->getNumRows(); i++) {
+						{
+							row_index = relationN(r).data->data_t->getRowIndex();
+							feature_data = &(relationN(r).data->data_t->getRow()); 
+							relationN(r).data->data_t->next();
+						}
+						double& v_if = v[row_index + attr_offset];
+					
+						for (uint i_fd = 0; i_fd < feature_data->size; i_fd++) {	
+							uint& train_case_index = feature_data->data[i_fd].id;		
+							FM_FLOAT& x_li = feature_data->data[i_fd].value;	
+							relN_cache(r)[train_case_index].q += v_if * x_li;
+						}
+					}
+					
+				}
 
 				// add 0.5*q^2 to e and set q to zero.
 				// O(n*|B|)
@@ -191,10 +220,17 @@ class fm_learn_mcmc : public fm_learn {
 					Data* m_data = main_data(ds);
 					for (uint c = 0; c < m_data->num_cases; c++) {
 						double q_all = m_cache[c].q;
-							for (uint r = 0; r < m_data->relation.dim; r++) {
+						double q_bs = 0.0;
+							for (uint r = 0; r < m_data->relation.dim; r++) { // Relation
 								q_all += rel_cache(r)[m_data->relation(r).data_row_to_relation_row(c)].q;
-							}					
-						m_cache[c].e += 0.5 * q_all*q_all;
+							}
+							// will substract (sum_i v^B_i,f x^B_i)^2 (== q^B,s) for bloack-based
+								for (uint r = 0; r < m_data->relationN.dim; r++) { // Relation N
+								q_all += relN_cache(r)[m_data->relationN(r).data_row_to_relation_row(c)].q;
+								q_bs += relN_cache(r)[m_data->relationN(r).data_row_to_relation_row(c)].q *
+										relN_cache(r)[m_data->relationN(r).data_row_to_relation_row(c)].q;
+							}
+						m_cache[c].e += 0.5 * (q_all*q_all - q_bs);
 						m_cache[c].q = 0.0;
 					}
 				}
@@ -202,22 +238,30 @@ class fm_learn_mcmc : public fm_learn {
 
 				// Calculate the "prediction" part of the relation y
 				// O(\sum_B n^B)
-				for (uint r = 0; r < relation.dim; r++) {
+				for (uint r = 0; r < relation.dim; r++) { // Relation
 					// add 0.5*q^2 to y and set q to zero.
 					for (uint c = 0; c <  relation(r).data->num_cases; c++) {
 						rel_cache(r)[c].y += 0.5 * rel_cache(r)[c].q * rel_cache(r)[c].q;
 						rel_cache(r)[c].q = 0.0;
 					}
 				}
+				for (uint r = 0; r < relationN.dim; r++) { // Relation N
+					// add 0.5*q^2 to y and set q to zero.
+					for (uint c = 0; c <  relationN(r).data->num_cases; c++) {
+						// this is for inner-interactions
+						//rel_cache(r)[c].y += 0.5 * rel_cache(r)[c].q * rel_cache(r)[c].q;
+						relN_cache(r)[c].q = 0.0;
+					}
+				}
 			}
-
+            
 			// (2) do -1/2 sum_f (sum_i v_if^2 x_i^2) and store it in the q-term
 			for (int f = 0; f < fm->num_factor; f++) {
 				double* v = fm->v.value[f];
 
 				// sum up the q^S_f terms in the main-q-cache: 0.5*sum_i (v_if x_i)^2 (== q^S_f-term)
 				// Complexity: O(N_z(X^M))
-				for (uint ds = 0; ds < main_cache.dim; ds++) {
+				for (uint ds = 0; ds < main_cache.dim; ds++) { // skip for relationN type
 					e_q_term* m_cache = main_cache(ds);
 					Data* m_data = main_data(ds);
 		
@@ -242,7 +286,7 @@ class fm_learn_mcmc : public fm_learn {
 
 				// sum up the q^B,S_f terms in the block_cache.q: 0.5* sum_i (v^B_if x^B_i)^2 (== q^B,S_f-term)
 				// Complexity: O(\sum_{B} N_z(X^B))
-				for (uint r = 0; r < relation.dim; r++) {
+				for (uint r = 0; r < relation.dim; r++) { // skip for block-based
 					uint attr_offset = relation(r).data->attr_offset;
 					relation(r).data->data_t->begin();
 					uint row_index;
@@ -272,7 +316,7 @@ class fm_learn_mcmc : public fm_learn {
 					m_data->data_t->begin();
 					uint row_index;
 					sparse_row<DATA_FLOAT>* feature_data;
-					for (uint i = 0; i < m_data->data_t->getNumRows(); i++) {
+					for (uint i = 0; i < m_data->data_t->getNumRows(); i++) { // for inner-interactions only
 						{
 							row_index = m_data->data_t->getRowIndex();
 							feature_data = &(m_data->data_t->getRow()); 
@@ -287,7 +331,7 @@ class fm_learn_mcmc : public fm_learn {
 						}
 					}
 				}
-				for (uint r = 0; r < relation.dim; r++) {
+				for (uint r = 0; r < relation.dim; r++) { // Relation
 					uint attr_offset = relation(r).data->attr_offset;
 					relation(r).data->data_t->begin();
 					uint row_index;
@@ -307,6 +351,27 @@ class fm_learn_mcmc : public fm_learn {
 						}
 					}
 				}
+				for (uint r = 0; r < relationN.dim; r++) { // Relation N
+					uint attr_offset = relationN(r).data->attr_offset;
+					relationN(r).data->data_t->begin();
+					uint row_index;
+					sparse_row<DATA_FLOAT>* feature_data;
+					for (uint i = 0; i < relationN(r).data->data_t->getNumRows(); i++) {
+						{
+							row_index = relationN(r).data->data_t->getRowIndex();
+							feature_data = &(relationN(r).data->data_t->getRow()); 
+							relationN(r).data->data_t->next();
+						}
+						double& w_i = fm->w(row_index + attr_offset);						
+
+						for (uint i_fd = 0; i_fd < feature_data->size; i_fd++) {	
+							uint& train_case_index = feature_data->data[i_fd].id;		
+							FM_FLOAT& x_li = feature_data->data[i_fd].value;	
+							relN_cache(r)[train_case_index].q += w_i * x_li; 
+						}
+					}
+				}
+
 
 			}	
 			// (3) merge both for getting the prediction: w0+e(c)+q(c)
@@ -316,8 +381,11 @@ class fm_learn_mcmc : public fm_learn {
 			
 				for (uint c = 0; c < m_data->num_cases; c++) {
 					double q_all = m_cache[c].q;
-					for (uint r = 0; r < m_data->relation.dim; r++) {
+					for (uint r = 0; r < m_data->relation.dim; r++) { // Relation
 						q_all += rel_cache(r)[m_data->relation(r).data_row_to_relation_row(c)].q;
+					}
+					for (uint r = 0; r < m_data->relationN.dim; r++) { // Relation N
+						q_all += relN_cache(r)[m_data->relationN(r).data_row_to_relation_row(c)].q;
 					}
 					m_cache[c].e = m_cache[c].e + q_all;
 					if (fm->k0) {
@@ -328,11 +396,20 @@ class fm_learn_mcmc : public fm_learn {
 			}
 
 			// The "prediction" in each block is calculated
+			// Relation
 			for (uint r = 0; r < relation.dim; r++) {
 				// y_i = y_i + q_i = [1/2 sum_f (q^B_if)^2] + [sum w^B_i x^B_i -1/2 sum_f (sum_i v^B_if^2 x^B_i^2)]
 				for (uint c = 0; c <  relation(r).data->num_cases; c++) {
 					rel_cache(r)[c].y = rel_cache(r)[c].y + rel_cache(r)[c].q;
 					rel_cache(r)[c].q = 0.0;
+				}
+			}
+			// Relation N
+			for (uint r = 0; r < relationN.dim; r++) {
+				// y_i = y_i + q_i = [1/2 sum_f (q^B_if)^2] + [sum w^B_i x^B_i -1/2 sum_f (sum_i v^B_if^2 x^B_i^2)]
+				for (uint c = 0; c <  relationN(r).data->num_cases; c++) {
+					relN_cache(r)[c].y = relN_cache(r)[c].y + relN_cache(r)[c].q;
+					relN_cache(r)[c].q = 0.0;
 				}
 			}
 
@@ -438,7 +515,12 @@ class fm_learn_mcmc : public fm_learn {
 				}
 				// draw w's of the main table for which there is no observation in the training data
 				uint draw_to = fm->num_attribute; 
-				if (train.relation.dim > 0) { draw_to = train.relation(0).data->attr_offset; } // draw up to the first relation table
+				if (train.relation.dim > 0) { // draw up to the first relation table
+					draw_to = train.relation(0).data->attr_offset;
+				}
+				else if (train.relationN.dim > 0) {
+					draw_to = train.relationN(0).data->attr_offset;
+				}
 				for (uint i = train.data_t->getNumRows(); i < draw_to; i++) {
 					row_index = i;
 					feature_data = &(empty_data_row);
@@ -446,10 +528,46 @@ class fm_learn_mcmc : public fm_learn {
 					draw_w(fm->w(row_index), w_mu(g), w_lambda(g), *feature_data);
 					count_how_many_variables_are_drawn++;
 				}
+				// Relation
 				// foreach relation do: draw w
 				for (uint r = 0; r < train.relation.dim; r++) {
 					RelationJoin& join = train.relation(r);
 					relation_cache* r_cache = rel_cache(r);
+					// init the e-cache for the blocks
+					for (uint c = 0; c < join.data->num_cases; c++) {
+						r_cache[c].we = 0;
+					}
+					for (uint c = 0; c < train.num_cases; c++) {
+						r_cache[join.data_row_to_relation_row(c)].we += cache[c].e;
+						cache[c].e -= r_cache[join.data_row_to_relation_row(c)].y; // let main.e be out of sync
+					}
+					// draw the w's:
+					join.data->data_t->begin();
+					uint row_index;
+					sparse_row<DATA_FLOAT>* feature_data;
+					for (uint i = 0; i < join.data->data_t->getNumRows(); i++) {
+						{
+							row_index = join.data->data_t->getRowIndex();
+							feature_data = &(join.data->data_t->getRow()); 
+							join.data->data_t->next();							
+							count_how_many_variables_are_drawn++;
+						}
+						uint g = meta->attr_group(row_index+join.data->attr_offset);
+						draw_w_rel(fm->w(row_index+join.data->attr_offset), w_mu(g), w_lambda(g), *feature_data, r_cache);
+					}
+					
+
+					// update the cache.e-Term!
+					for (uint c = 0; c < train.num_cases; c++) {
+						cache[c].e += r_cache[join.data_row_to_relation_row(c)].y; // sync main.e again
+					}
+					
+				}
+				// Relation N
+				// foreach relation do: draw w
+				for (uint r = 0; r < train.relationN.dim; r++) {
+					RelationJoin& join = train.relationN(r);
+					relation_cache* r_cache = relN_cache(r);
 					// init the e-cache for the blocks
 					for (uint c = 0; c < join.data->num_cases; c++) {
 						r_cache[c].we = 0;
@@ -509,6 +627,7 @@ class fm_learn_mcmc : public fm_learn {
 			
 				double* v = fm->v.value[f];
 				
+				// Relation
 				for (uint r = 0; r < train.relation.dim; r++) {
 					RelationJoin& join = train.relation(r);
 					relation_cache* r_cache = rel_cache(r);
@@ -534,12 +653,44 @@ class fm_learn_mcmc : public fm_learn {
 						}
 					}
 				}
+				// Relation N
+				for (uint r = 0; r < train.relationN.dim; r++) {
+					RelationJoin& join = train.relationN(r);
+					relation_cache* r_cache = relN_cache(r);
+					for (uint c = 0; c < join.data->num_cases; c++) {
+						r_cache[c].q = 0.0;
+					}
+					uint attr_offset = join.data->attr_offset;
+					join.data->data_t->begin();
+					uint row_index;
+					sparse_row<DATA_FLOAT>* feature_data;
+					for (uint i = 0; i < join.data->data_t->getNumRows(); i++) {
+						{
+							row_index = join.data->data_t->getRowIndex();
+							feature_data = &(join.data->data_t->getRow()); 
+							join.data->data_t->next();
+						}
+						double& v_if = v[row_index + attr_offset];
+				
+						for (uint i_fd = 0; i_fd < feature_data->size; i_fd++) {	
+							uint& train_case_index = feature_data->data[i_fd].id;		
+							FM_FLOAT& x_li = feature_data->data[i_fd].value;	
+							r_cache[train_case_index].q += v_if * x_li;			
+						}
+					}
+				}
+
+
 
 				// sum q^M over its relations:
 				for (uint c = 0; c < train.num_cases; c++) {
-					for (uint r = 0; r < train.relation.dim; r++) {
+					for (uint r = 0; r < train.relation.dim; r++) { // Relation
 						cache[c].q += rel_cache(r)[train.relation(r).data_row_to_relation_row(c)].q; // if do innerblock, then it contains q^M + sum q^B otherwise just sum q^B
 					}
+					for (uint r = 0; r < train.relationN.dim; r++) { // Relation N
+						cache[c].q += relN_cache(r)[train.relationN(r).data_row_to_relation_row(c)].q;
+					}
+
 				} 
 
 				// draw the thetas from their posterior
@@ -558,7 +709,12 @@ class fm_learn_mcmc : public fm_learn {
 				}		
 				// draw v's of the main table for which there is no observation in the training data
 				uint draw_to = fm->num_attribute; 
-				if (train.relation.dim > 0) { draw_to = train.relation(0).data->attr_offset; } // draw up to the first relation table
+				if (train.relation.dim > 0) { // draw up to the first relation table
+					draw_to = train.relation(0).data->attr_offset;
+				} 
+				else if (train.relationN.dim > 0) {
+					draw_to = train.relationN(0).data->attr_offset;
+				}
 				for (uint i = train.data_t->getNumRows(); i < draw_to; i++) {
 					row_index = i;
 					feature_data = &(empty_data_row);
@@ -566,7 +722,8 @@ class fm_learn_mcmc : public fm_learn {
 					draw_v(v[row_index], v_mu(g,f), v_lambda(g,f), *feature_data);
 					count_how_many_variables_are_drawn++;
 				}
-
+                
+				// Relation
 				// foreach relation do: draw v	
 				for (uint r = 0; r < train.relation.dim; r++) {
 					RelationJoin& join = train.relation(r);
@@ -601,6 +758,49 @@ class fm_learn_mcmc : public fm_learn {
 						}
 						uint g = meta->attr_group(row_index+join.data->attr_offset);
 						draw_v_rel(v[row_index+join.data->attr_offset], v_mu(g,f), v_lambda(g,f), *feature_data, r_cache);
+					}					
+
+					// update the cache.e and cache.q terms
+					for (uint c = 0; c < train.num_cases; c++) {
+						cache[c].e += (r_cache[join.data_row_to_relation_row(c)].y + cache[c].q*r_cache[join.data_row_to_relation_row(c)].q); // sync e-term
+						cache[c].q += r_cache[join.data_row_to_relation_row(c)].q; // sync q-term
+					}		
+				}
+				// Relation N
+				// foreach relation do: draw v	
+				for (uint r = 0; r < train.relationN.dim; r++) {
+					RelationJoin& join = train.relationN(r);
+					relation_cache* r_cache = relN_cache(r);
+					// init for the block: c, c_sqr, e, eq
+					// unsync main: q and e
+					for (uint c = 0; c < join.data->num_cases; c++) {
+						r_cache[c].we = 0.0;
+						r_cache[c].weq = 0.0;
+						r_cache[c].wc = 0.0;
+						r_cache[c].wc_sqr = 0.0;
+					}					
+					for (uint c = 0; c < train.num_cases; c++) {
+						cache[c].q -= r_cache[join.data_row_to_relation_row(c)].q; // let main.q be out of sync
+						r_cache[join.data_row_to_relation_row(c)].we += cache[c].e;
+						r_cache[join.data_row_to_relation_row(c)].weq += (cache[c].e * cache[c].q);
+						r_cache[join.data_row_to_relation_row(c)].wc += cache[c].q;
+						r_cache[join.data_row_to_relation_row(c)].wc_sqr += (cache[c].q*cache[c].q);
+						cache[c].e -= (r_cache[join.data_row_to_relation_row(c)].y + cache[c].q*r_cache[join.data_row_to_relation_row(c)].q); // let main.e be out of sync
+					}
+				
+					// draw the v's:
+					join.data->data_t->begin();
+					uint row_index;
+					sparse_row<DATA_FLOAT>* feature_data;
+					for (uint i = 0; i < join.data->data_t->getNumRows(); i++) {
+						{
+							row_index = join.data->data_t->getRowIndex();
+							feature_data = &(join.data->data_t->getRow()); 
+							join.data->data_t->next();
+							count_how_many_variables_are_drawn++;
+						}
+						uint g = meta->attr_group(row_index+join.data->attr_offset);
+						draw_v_relN(v[row_index+join.data->attr_offset], v_mu(g,f), v_lambda(g,f), *feature_data, r_cache);
 					}					
 
 					// update the cache.e and cache.q terms
@@ -889,6 +1089,74 @@ class fm_learn_mcmc : public fm_learn {
 			}
 		}
 
+		// RELATION N: Find the optimal value for the 2-way interaction parameter v: RELATION
+		void draw_v_relN(double& v, double& v_mu, double& v_lambda, sparse_row<DATA_FLOAT>& feature_data, relation_cache* r_cache) {
+			double v_sigma_sqr = 0;
+			double v_mean = 0;
+			// v_sigma_sqr = \sum h^2
+			// v_mean = \sum h*e
+			uint num_all = 0;
+			for (uint i_fd = 0; i_fd < feature_data.size; i_fd++) {	
+				uint& train_case_index = feature_data.data[i_fd].id;		
+				FM_FLOAT x_li = feature_data.data[i_fd].value;	
+				relation_cache* cache_li = &(r_cache[train_case_index]);
+				//double h = x_li * ( cache_li->q - x_li * v);
+				//v_mean += (h*cache_li->we + x_li*cache_li->weq);
+				v_mean += x_li * cache_li->weq;
+				//v_sigma_sqr += (h * h * cache_li->wnum + 2 * cache_li->wc * x_li * h + x_li * x_li * cache_li->wc_sqr);
+				v_sigma_sqr += x_li * x_li * cache_li->wc_sqr;
+				num_all += r_cache[train_case_index].wnum;
+			}
+			// v_mean = \sum h*e - theta * \sum h^2 
+			v_mean -= v * v_sigma_sqr;
+			// final posterior distr:
+			v_sigma_sqr = (double) 1.0 / (v_lambda + alpha * v_sigma_sqr);
+			v_mean = - v_sigma_sqr * (alpha * v_mean - v_mu * v_lambda);  
+
+			// update v:
+			double v_old = v; 
+			if (std::isnan(v_sigma_sqr) || std::isinf(v_sigma_sqr)) { 
+				v = 0.0;
+			} else {
+				if (do_sample) {
+					v = ran_gaussian(v_mean, std::sqrt(v_sigma_sqr));
+				} else {
+					v = v_mean;
+				}
+			}
+
+			// check for out of bounds values
+			if (std::isnan(v)) {
+				nan_cntr_v++;
+				v = v_old;
+				assert(! std::isnan(v_old));
+				assert(! std::isnan(v));
+				return;
+			}
+			if (std::isinf(v)) {
+				inf_cntr_v++;
+				v = v_old;
+				assert(! std::isinf(v_old));
+				assert(! std::isinf(v));
+				return;
+			}
+
+			// update error and q:
+			for (uint i_fd = 0; i_fd < feature_data.size; i_fd++) {	
+				uint& train_case_index = feature_data.data[i_fd].id;		
+				FM_FLOAT x_li = feature_data.data[i_fd].value;	
+				relation_cache* cache_li = &(r_cache[train_case_index]);
+				//double h = x_li * ( cache_li->q - x_li * v_old);
+				//cache_li->we -= (v_old - v) * (h * cache_li->wnum + x_li * cache_li->wc);
+				cache_li->we -= (v_old - v) * (x_li * cache_li->wc);
+				cache_li->q -= (v_old - v) * x_li;
+				//cache_li->weq -= (v_old - v) * (h * cache_li->wc + x_li * cache_li->wc_sqr);
+				cache_li->weq -= (v_old - v) * (x_li * cache_li->wc_sqr);
+				//cache_li->y += (v-v_old) * h;
+			}
+		}
+
+
 		void draw_alpha(double& alpha, uint num_train_total) {
 			if (! do_multilevel) {
 				alpha = alpha_0;
@@ -1156,6 +1424,7 @@ class fm_learn_mcmc : public fm_learn {
 			MemoryLog::getInstance().logNew("e_q_term", sizeof(e_q_term), test.num_cases);
 			cache_test = new e_q_term[test.num_cases];
 
+			// Relation
 			rel_cache.setSize(train.relation.dim);
 			for (uint r = 0; r < train.relation.dim; r++) {
 				MemoryLog::getInstance().logNew("relation_cache", sizeof(relation_cache), train.relation(r).data->num_cases);
@@ -1165,10 +1434,28 @@ class fm_learn_mcmc : public fm_learn {
 				}
 			}
 
+			// Relation N
+			relN_cache.setSize(train.relationN.dim);
+			for (uint r = 0; r < train.relationN.dim; r++) {
+				MemoryLog::getInstance().logNew("relation_cache", sizeof(relation_cache), train.relationN(r).data->num_cases);
+				relN_cache(r) = new relation_cache[train.relationN(r).data->num_cases];
+				for (uint c = 0; c < train.relationN(r).data->num_cases; c++) {
+					relN_cache(r)[c].wnum = 0;
+				}
+			}
+
+
 			// calculate #^R
+			// Relation
 			for (uint r = 0; r < train.relation.dim; r++) {
 				for (uint c = 0; c < train.relation(r).data_row_to_relation_row.dim; c++) {
 					rel_cache(r)[train.relation(r).data_row_to_relation_row(c)].wnum += 1.0;
+				}
+			}
+			// Relation N
+			for (uint r = 0; r < train.relationN.dim; r++) {
+				for (uint c = 0; c < train.relationN(r).data_row_to_relation_row.dim; c++) {
+					relN_cache(r)[train.relationN(r).data_row_to_relation_row(c)].wnum += 1.0;
 				}
 			}
 

--- a/src/libfm/src/fm_learn_mcmc_simultaneous.h
+++ b/src/libfm/src/fm_learn_mcmc_simultaneous.h
@@ -59,7 +59,6 @@ class fm_learn_mcmc_simultaneous : public fm_learn_mcmc {
 			main_cache(0) = cache;
 			main_cache(1) = cache_test;
 	
-
 			predict_data_and_write_to_eterms(main_data, main_cache);
 			if (task == TASK_REGRESSION) {
 				// remove the target from each prediction, because: e(c) := \hat{y}(c) - target(c)


### PR DESCRIPTION
Dear Rendle,

I was trying to add a format that will ignore/eliminate the inner-interactions within a relation data (BS format). What do you think about this function? The idea is that the interactions in the same relation file might not be meaningful, such as the interaction between a user and his/her profile. I remember this is also mentioned in one of your work. I tested the code with small movie-lens dataset. The result looks okay. If you like it, could you have a review on the codes?

In addition, I am not sure whether I shall modify the update for the hyper-parameters or not. It would be great if you can give me some directions or related references to study. I think I'm not fully understand how to derive them by reading only the Bayesian Factorization Machines paper.

Sincerely,
